### PR TITLE
feat(graph): add GraphState TypedDict and LangGraph skeleton (#2)

### DIFF
--- a/backend/app/graph/graph.py
+++ b/backend/app/graph/graph.py
@@ -5,9 +5,6 @@ from langgraph.checkpoint.memory import MemorySaver
 
 from app.graph.state import GraphState
 
-# Module-level singleton — compiled once at import time
-_graph = None
-
 
 def _build_graph():
     """Build and compile the StateGraph with a MemorySaver checkpointer."""
@@ -25,9 +22,10 @@ def _build_graph():
     return builder.compile(checkpointer=checkpointer)
 
 
+# Compiled once at module import time — no lazy initialisation needed
+_graph = _build_graph()
+
+
 def get_graph():
-    """Return the compiled graph singleton, initialising it on first call."""
-    global _graph
-    if _graph is None:
-        _graph = _build_graph()
+    """Return the compiled graph singleton."""
     return _graph

--- a/backend/app/graph/graph.py
+++ b/backend/app/graph/graph.py
@@ -1,0 +1,33 @@
+# LangGraph StateGraph setup — skeleton with MemorySaver checkpointer
+
+from langgraph.graph import StateGraph, END
+from langgraph.checkpoint.memory import MemorySaver
+
+from app.graph.state import GraphState
+
+# Module-level singleton — compiled once at import time
+_graph = None
+
+
+def _build_graph():
+    """Build and compile the StateGraph with a MemorySaver checkpointer."""
+    builder = StateGraph(GraphState)
+
+    # Placeholder no-op node — real agent nodes are wired in by later tickets
+    def noop(state: GraphState) -> dict:
+        return {}
+
+    builder.add_node("noop", noop)
+    builder.set_entry_point("noop")
+    builder.add_edge("noop", END)
+
+    checkpointer = MemorySaver()
+    return builder.compile(checkpointer=checkpointer)
+
+
+def get_graph():
+    """Return the compiled graph singleton, initialising it on first call."""
+    global _graph
+    if _graph is None:
+        _graph = _build_graph()
+    return _graph

--- a/backend/app/graph/state.py
+++ b/backend/app/graph/state.py
@@ -1,0 +1,17 @@
+# Shared state that flows through every LangGraph node
+
+from typing import Annotated
+from typing_extensions import TypedDict
+from langchain_core.messages import BaseMessage
+from langgraph.graph.message import add_messages
+
+
+class GraphState(TypedDict):
+    # Conversation history — append-only via add_messages reducer
+    messages: Annotated[list[BaseMessage], add_messages]
+    # Which repo the user is querying
+    repo_name: str
+    # Code chunks retrieved by the RAG/code-writer agents
+    retrieved_chunks: list[str]
+    # Routing decision set by the Supervisor node
+    route: str

--- a/backend/app/graph/state.py
+++ b/backend/app/graph/state.py
@@ -1,7 +1,7 @@
 # Shared state that flows through every LangGraph node
 
 from typing import Annotated
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, NotRequired
 from langchain_core.messages import BaseMessage
 from langgraph.graph.message import add_messages
 
@@ -11,7 +11,7 @@ class GraphState(TypedDict):
     messages: Annotated[list[BaseMessage], add_messages]
     # Which repo the user is querying
     repo_name: str
-    # Code chunks retrieved by the RAG/code-writer agents
-    retrieved_chunks: list[str]
-    # Routing decision set by the Supervisor node
-    route: str
+    # Code chunks retrieved by the RAG/code-writer agents (set by agent nodes)
+    retrieved_chunks: NotRequired[list[str]]
+    # Routing decision set by the Supervisor node (absent until Supervisor runs)
+    route: NotRequired[str]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,13 +6,15 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
 from app.api.health import router as health_router
+from app.graph.graph import get_graph
 
 
 # lifespan handles startup and shutdown logic cleanly
 # anything before `yield` runs on startup, after yield runs on shutdown
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # startup
+    # startup — compile the graph singleton once so it's ready for requests
+    get_graph()
     print(f"🚀 {settings.app_name} starting up...")
     yield
     # shutdown

--- a/backend/tests/test_graph_state.py
+++ b/backend/tests/test_graph_state.py
@@ -1,0 +1,61 @@
+# Tests for Graph State & Skeleton (Issue #2)
+
+import pytest
+from langchain_core.messages import HumanMessage, AIMessage
+from langgraph.graph.message import add_messages
+
+from app.graph.state import GraphState
+from app.graph.graph import get_graph
+
+
+# ── State field tests ──────────────────────────────────────────────────────────
+
+
+def test_graph_state_fields_exist():
+    """GraphState has the required keys."""
+    required = {"messages", "repo_name", "retrieved_chunks", "route"}
+    assert required == set(GraphState.__annotations__.keys())
+
+
+def test_add_messages_appends():
+    """add_messages reducer appends rather than replaces."""
+    existing = [HumanMessage(content="hello")]
+    new_msg = AIMessage(content="world")
+
+    result = add_messages(existing, [new_msg])
+
+    assert len(result) == 2
+    assert result[0].content == "hello"
+    assert result[1].content == "world"
+
+
+def test_add_messages_does_not_replace():
+    """add_messages with two calls accumulates all messages."""
+    msgs = [HumanMessage(content="first")]
+    after_first = add_messages([], msgs)
+    after_second = add_messages(after_first, [HumanMessage(content="second")])
+
+    assert len(after_second) == 2
+
+
+# ── Graph invocation test ─────────────────────────────────────────────────────
+
+
+def test_get_graph_returns_singleton():
+    """get_graph() returns the same object on repeated calls."""
+    g1 = get_graph()
+    g2 = get_graph()
+    assert g1 is g2
+
+
+def test_graph_invoke_without_error():
+    """Graph can be invoked with minimal input and returns without raising."""
+    graph = get_graph()
+    config = {"configurable": {"thread_id": "test-thread"}}
+    result = graph.invoke(
+        {"messages": [HumanMessage(content="hello")], "repo_name": "test"},
+        config=config,
+    )
+    # messages should still be present after invocation
+    assert "messages" in result
+    assert len(result["messages"]) >= 1

--- a/backend/tests/test_graph_state.py
+++ b/backend/tests/test_graph_state.py
@@ -1,6 +1,6 @@
 # Tests for Graph State & Skeleton (Issue #2)
 
-import pytest
+from typing import get_type_hints
 from langchain_core.messages import HumanMessage, AIMessage
 from langgraph.graph.message import add_messages
 
@@ -12,9 +12,10 @@ from app.graph.graph import get_graph
 
 
 def test_graph_state_fields_exist():
-    """GraphState has the required keys."""
+    """GraphState has (at least) the four required fields."""
     required = {"messages", "repo_name", "retrieved_chunks", "route"}
-    assert required == set(GraphState.__annotations__.keys())
+    # Use issubset so adding fields in future tickets doesn't break this test
+    assert required.issubset(set(get_type_hints(GraphState).keys()))
 
 
 def test_add_messages_appends():
@@ -49,13 +50,16 @@ def test_get_graph_returns_singleton():
 
 
 def test_graph_invoke_without_error():
-    """Graph can be invoked with minimal input and returns without raising."""
+    """Graph can be invoked with only the required fields and returns without raising.
+
+    retrieved_chunks and route are NotRequired — they are absent on the first
+    turn and populated later by agent nodes, so omitting them here is valid.
+    """
     graph = get_graph()
-    config = {"configurable": {"thread_id": "test-thread"}}
+    config = {"configurable": {"thread_id": "test-thread-invoke"}}
     result = graph.invoke(
         {"messages": [HumanMessage(content="hello")], "repo_name": "test"},
         config=config,
     )
-    # messages should still be present after invocation
     assert "messages" in result
     assert len(result["messages"]) >= 1


### PR DESCRIPTION
## Summary
Defines the shared `GraphState` TypedDict and wires up a compilable `StateGraph` with `MemorySaver` checkpointer — the foundational plumbing required by all agent tickets.

## Changes
- `backend/app/graph/state.py` — `GraphState` with `messages` (append-only via `add_messages`), `repo_name`, and `NotRequired` fields `retrieved_chunks` + `route`
- `backend/app/graph/graph.py` — eager module-level graph compilation, `get_graph()` singleton accessor
- `backend/app/main.py` — calls `get_graph()` at startup lifespan
- `backend/tests/test_graph_state.py` — 5 unit tests covering field existence, `add_messages` accumulation, singleton identity, and end-to-end invocation

## Testing
5 unit tests added in `backend/tests/test_graph_state.py`, all passing.

## Review
Approved on round 2. Round 1 fixes: removed unused import, switched to eager init (thread-safe), relaxed field assertion to `issubset`, made `retrieved_chunks`/`route` `NotRequired`.

## QA
PASSED — all 5 tests pass; pre-existing `scripts/test_parser.py` collection error on main is unrelated.

Closes #2